### PR TITLE
Use lists:keysearch/3 instead of lists:keyfind/3.

### DIFF
--- a/src/gen_leader.erl
+++ b/src/gen_leader.erl
@@ -1443,8 +1443,8 @@ mon_handle_req({monitor, P}, From, Refs) ->
                {_Name, N}           -> N;
                Pid when is_pid(Pid) -> node(Pid)
            end,
-    case lists:keyfind(Node, 2, Refs) of
-        {_, Ref} ->
+    case lists:keysearch(Node, 2, Refs) of
+        {value, {_, Ref}} ->
             mon_reply(From, {Ref,Node}),
             Refs;
         false ->


### PR DESCRIPTION
Some erlang distributions (R12B and below) doesn't have lists:keyfind/3
function. It's better (for compatibility reasons) to use lists:keysearch/3 instead - it's available
everywhere.

Signed-off-by: Peter Lemenkov lemenkov@gmail.com
